### PR TITLE
List value labels that do not match pattern

### DIFF
--- a/src/ado/lbl_list_matching_vals.ado
+++ b/src/ado/lbl_list_matching_vals.ado
@@ -5,7 +5,7 @@ cap program drop   lbl_list_matching_vals
 
     version 17
 
-    syntax [varlist], pattern(string) [negate verbose]
+    syntax [varlist], pattern(string) [NEGate Verbose]
 
     qui {
 

--- a/src/ado/lbl_list_matching_vals.ado
+++ b/src/ado/lbl_list_matching_vals.ado
@@ -1,0 +1,97 @@
+*! version XX XXXXXXXXX ADAUTHORNAME ADCONTACTINFO
+
+cap program drop   lbl_list_matching_vals
+    program define lbl_list_matching_vals, rclass
+
+    version 17
+
+    syntax [varlist], pattern(string) [negate verbose]
+
+    qui {
+
+      * get list of variables with value labels
+      ds `varlist', has(vallabel)
+      local vars_w_val_lbl "`r(varlist)'"
+      local n_vars_w_val_lbl : list sizeof vars_w_val_lbl
+
+      * compile the list of labels with matching elements
+      * by working in a frame so that the data can be converted into
+      * a data set of labels
+      tempname val_lbls
+      frame copy default `val_lbls'
+      frame `val_lbls' {
+
+        * keep variables of interest
+        keep `vars_w_val_lbl'
+
+        * create a data set of labels
+        uselabel, clear var
+        
+        * capture the list of value labels with a matching element
+        d // for computing observation count
+        if (`r(N)' == 0) {
+          local val_lbls_w_matching_val ""
+        }
+        else if (`r(N)' > 0) {
+
+          * labels that match
+          levelsof lname if ustrregexm(label, "`pattern'"), ///
+            local(val_lbls_w_matching_val) clean
+          
+          * construct labels that do not match, if negate option provided
+          if (!mi("`negate'")) {
+            * all label names
+            levelsof lname, local(all_val_lbls) clean
+            * labels to exclude
+            local val_lbls_to_exclude "`val_lbls_w_matching_val'"
+            * compliment of matching labels
+            local val_lbls_w_matching_val : list all_val_lbls - val_lbls_to_exclude
+          }
+
+        }
+
+      }
+
+      * compile list of variables with whose value labels have a matching element
+      if (mi("`val_lbls_w_matching_val'")) {
+        local vars_w_matching_val_lbl ""
+      }
+      else if (!mi("`val_lbls_w_matching_val'")) {
+        * list variables with one of the variable label names piped into `has()'
+        ds, has(vallabel `val_lbls_w_matching_val')
+        local vars_w_matching_val_lbl "`r(varlist)'"
+      }
+
+      * compile the list of matching labels
+      * capture this from the val_lbls frame so that present in main frame
+      local val_lbls_w_matching_val "`val_lbls_w_matching_val'"
+
+      * compute the number of matches
+      local n_matching_val_lbls : list sizeof val_lbls_w_matching_val
+      local n_matching_vars : list sizeof vars_w_matching_val_lbl
+
+      * report on findings
+      if (`n_matching_val_lbls' == 0) {
+        noi: di as result "No matching value labels found"
+      }
+      else if (`n_matching_val_lbls' > 0) {
+        * print basic results message
+        noi: di as result "Matching value labels found."
+        noi: di as result "`n_matching_val_lbls' value labels attached to `n_matching_vars' variables."
+        noi: di as result "Value labels: `val_lbls_w_matching_val'"
+        noi: di as result "Variables: `vars_w_matching_val_lbl'"
+        * if verbose mode, print out matching value label sets
+        if (!mi("`verbose'")) {
+          noi: label list `val_lbls_w_matching_val'
+        }
+      }
+
+      * return results
+      return local lbl_count "`n_matching_val_lbls'"
+      return local val_lbl_list "`val_lbls_w_matching_val'"
+      return local var_count "`n_matching_vars'"
+      return local varlist "`vars_w_matching_val_lbl'"
+
+    }
+
+end

--- a/src/ado/lbl_list_matching_vals.ado
+++ b/src/ado/lbl_list_matching_vals.ado
@@ -3,9 +3,9 @@
 cap program drop   lbl_list_matching_vals
     program define lbl_list_matching_vals, rclass
 
-    version 17
+    version 14
 
-    syntax, pattern(string) [NEGate Verbose varlist(varlist)]
+    syntax, pattern(string) [NEGate VERbose Varlist(varlist)]
 
     qui {
 

--- a/src/dev/run-adodown-util.do
+++ b/src/dev/run-adodown-util.do
@@ -4,7 +4,7 @@
   }
   * Fill in your root path here
   if "`c(username)'" == "wb393438" {
-      global clone "C:\Users\wb393438\stata_funs\labeller"
+      global clone "C:\Users\wb393438\stata_funs\labeller\labeller"
   }
 
   // ad_setup, adf("${clone}")  ///

--- a/src/labeller.pkg
+++ b/src/labeller.pkg
@@ -25,11 +25,13 @@ f ado/lbl_list_no_var_lbl.ado
 f ado/lbl_replace_pipe.ado
 f ado/lbl_assert_no_pipes.ado
 f ado/lbl_list_pipes.ado
+f ado/lbl_list_matching_vals.ado
 f ado/labeller.ado
 f ado/lbl_assert_no_long_varlbl.ado
 f ado/lbl_list_long_varlbl.ado
 
 *** helpfiles
+f sthlp/lbl_list_matching_vals.sthlp
 f sthlp/lbl_assert_var_have_lbl.sthlp
 f sthlp/lbl_list_no_var_lbl.sthlp
 f sthlp/lbl_assert_no_long_varlbl.sthlp

--- a/src/mdhlp/lbl_list_matching_vals.md
+++ b/src/mdhlp/lbl_list_matching_vals.md
@@ -61,7 +61,7 @@ lbl_list_matching_vals, pattern("[Oo]ui")
 
 * find value labels and print out the contents of the label, for convenience
 * i.e., to avoid the next step that many users might logically make: 
-* `label list matching_lbl`
+* `label list matching_lbl` 
 lbl_list_matching_vals, pattern("[Oo]ui") verbose
 ```
 

--- a/src/mdhlp/lbl_list_matching_vals.md
+++ b/src/mdhlp/lbl_list_matching_vals.md
@@ -1,29 +1,107 @@
 # Title
 
-__lbl_list_matching_vals__ - This command is used for short description.
+__lbl_list_matching_vals__ - List value labels whose labels match a pattern.
 
 # Syntax
 
-__lbl_list_matching_vals__ , __**opt**ion1__(_string_)
+__lbl_list_matching_vals__ [varlist], __pattern__(_string_) [__**neg**ate__ __**v**erbose__]
 
 | _options_ | Description |
 |-----------|-------------|
-| __**opt**ion1__(_string_)   | Short description of option1  |
+| __pattern__(_string_)   | Pattern to find in an answer option. Provide either a substring or a regular expression.  |
+| __**neg**ate__   | Inverts the search, returning value labels that do __not__match the pattern.  |
+| __**v**erbose__   | Print out labels that match query. Output corresponds to `label list lblnames`.  |
 
 # Description
-<!-- Longer description of the intended use of the command and best practices related to the usage. -->
+
+While Stata offers some tools for searching the content of variable labels (e.g. `lookfor`), it does not have any methods for similarly searching the contents of value labels.
+
+This command aims fill this gap by:
+
+- Searching labels in value labels for a pattern
+- Identifying variable labels that contain labels of interest
+- Compiling variables that have these labels of interest attached
+
+This command can be particularly useful for checking that variable do (not) contain patterns of interest. Consider for example:
+
+- Confirming that value labels contain (e.g., no)
+- Identifying value labels that deviate from standards
 
 # Options
-<!-- Longer description (paragraph length) of all options, their intended use case and best practices related to them. -->
 
-__**opt**ion1__(_string_) is used for xyz. Longer description (paragraph length) of all options, their intended use case and best practices related to them.
+__pattern__(_string_) provides the text pattern to find in the contents of value labels. Rather be the traitional Stata glob pattern, this pattern is a sub-string or a regular expression.
+
+__negate__ inverts the search, returning value labels that do __not__match the pattern. In isolation, `pattern("my_text")` looks for value labels containing `"my_text"`. With `negate`, `pattern("my_search")` search looks instead for value labels that do not contain `"my_text"`.
+
+__verbose__ manages the how much output is printed. If the `verbose` option is not provided, `lbl_list_matching_vals` reports on whether any matches were found--and, if so, how many value labels match and how many variables the matching value labels describe. If the `verbose` option is specified, the command will additionally print the contents of the matching value labels as a convenience.
 
 # Examples
-<!-- A couple of examples to help the user get started and a short explanation of each of them. -->
+
+## Example 1: contain a pattern
+
+```
+* create some fake data
+gen var1 = .
+gen var2 = .
+gen var3 = .
+gen var4 = .
+
+* create some value labels
+label define var1_lbl 1 "Yes" 2 "No"
+label define var2_lbl 1 "Oui" 2 "Non" 3 "Oui, oui"
+label define var4_lbl 1 "Oui" 2 "Non"
+
+* apply those labels to some, but not all, variables
+label values var1 var1_lbl
+label values var2 var2_lbl
+label values var4 var4_lbl
+
+* find value labels with "Oui" and/or "oui" in at least one constituent label
+lbl_list_matching_vals, pattern("[Oo]ui")
+
+* find value labels and print out the contents of the label, for convenience
+* i.e., to avoid the next step that many users might logically make: 
+* `label list matching_lbl`
+lbl_list_matching_vals, pattern("[Oo]ui") verbose
+```
+
+## Example 2: do not contain a pattern
+
+```
+* find value labels that do not contain a certain pattern
+* for example, no "Oui"/"oui" in yes/no labels from a French-language survey 
+lbl_list_matching_vals, pattern("[Oo]ui") negate
+```
+
+## Example 3: contain only a certain set of characters
+
+```
+* create some value labels
+label drop _all
+* var1_lbl var2_lbl var4_lbl
+label define var1_lbl 1 "YES" 2 "NO"
+label define var2_lbl 1 "Yes" 2 "No"
+label define var3_lbl 1 "yes" 2 "no"
+label define var4_lbl 1 "Où" 2 "Là"
+
+* attach them to variables created above
+label values var1 var1_lbl
+label values var2 var2_lbl
+label values var3 var3_lbl
+label values var4 var4_lbl
+
+* contains no lower-case characters
+lbl_list_matching_vals, pattern("[:lower:]") negate
+
+* contains no French characters
+lbl_list_matching_vals, pattern("[àâäÀÂÄéèêëÉÈÊËîïôöÔÖùûüçÇ]") negate
+
+```
 
 # Feedback, bug reports and contributions
-<!-- A couple of examples to help the user get started and a short explanation of each of them. -->
+
+Read more about these commands on [this repo](https://github.com/lsms-worldbank/labeller) where this package is developed. Please provide any feedback by [opening an issue](https://github.com/lsms-worldbank/labeller/issues). PRs with suggestions for improvements are also greatly appreciated.
 
 # Authors
 
-TODO: Populate this field from .pkg file
+LSMS Team, The World Bank lsms@worldbank.org

--- a/src/mdhlp/lbl_list_matching_vals.md
+++ b/src/mdhlp/lbl_list_matching_vals.md
@@ -4,14 +4,14 @@ __lbl_list_matching_vals__ - List value labels whose labels match a pattern.
 
 # Syntax
 
-__lbl_list_matching_vals__ [varlist], __pattern__(_string_) [__**neg**ate__ __**v**erbose__]
+__lbl_list_matching_vals__, __pattern__(_string_) [__**neg**ate__ __**ver**bose__ __**v**arlist__(_varlist_)]
 
 | _options_ | Description |
 |-----------|-------------|
 | __pattern__(_string_)   | Pattern to find in an answer option. Provide either a substring or a regular expression.  |
 | __**neg**ate__   | Inverts the search, returning value labels that do __not__match the pattern.  |
-| __**v**erbose__   | Print out labels that match query. Output corresponds to `label list lblnames`.  |
-| __varlist__(_varlist_) | Restrict the scope of variables to consider |
+| __**ver**bose__   | Print out labels that match query. Output corresponds to `label list lblnames`.  |
+| __**v**arlist__(_varlist_) | Restrict the scope of variables to consider |
 
 # Description
 
@@ -32,9 +32,11 @@ This command can be particularly useful for checking that variable do (not) cont
 
 __pattern__(_string_) provides the text pattern to find in the contents of value labels. Rather be the traitional Stata glob pattern, this pattern is a sub-string or a regular expression.
 
-__negate__ inverts the search, returning value labels that do __not__match the pattern. In isolation, `pattern("my_text")` looks for value labels containing `"my_text"`. With `negate`, `pattern("my_search")` search looks instead for value labels that do not contain `"my_text"`.
+__**neg**ate__ inverts the search, returning value labels that do __not__match the pattern. In isolation, `pattern("my_text")` looks for value labels containing `"my_text"`. With `negate`, `pattern("my_search")` search looks instead for value labels that do not contain `"my_text"`.
 
-__verbose__ manages the how much output is printed. If the `verbose` option is not provided, `lbl_list_matching_vals` reports on whether any matches were found--and, if so, how many value labels match and how many variables the matching value labels describe. If the `verbose` option is specified, the command will additionally print the contents of the matching value labels as a convenience.
+__**ver**bose__ manages the how much output is printed. If the `verbose` option is not provided, `lbl_list_matching_vals` reports on whether any matches were found--and, if so, how many value labels match and how many variables the matching value labels describe. If the `verbose` option is specified, the command will additionally print the contents of the matching value labels as a convenience.
+
+__**v**arlist__(_varlist_) restricts the scope of the search to the user-provided variable list. By default, the command searches for matches in all variables in memory. With __varlist__(), the scope of the search can be narrowed.
 
 # Examples
 
@@ -61,8 +63,8 @@ label values var4 var4_lbl
 lbl_list_matching_vals, pattern("[Oo]ui")
 
 * find value labels and print out the contents of the label, for convenience
-* i.e., to avoid the next step that many users might logically make: 
-* `label list matching_lbl` 
+* i.e., to avoid the next step that many users might logically make:
+* `label list matching_lbl`
 lbl_list_matching_vals, pattern("[Oo]ui") verbose
 ```
 
@@ -70,7 +72,7 @@ lbl_list_matching_vals, pattern("[Oo]ui") verbose
 
 ```
 * find value labels that do not contain a certain pattern
-* for example, no "Oui"/"oui" in yes/no labels from a French-language survey 
+* for example, no "Oui"/"oui" in yes/no labels from a French-language survey
 lbl_list_matching_vals, pattern("[Oo]ui") negate
 ```
 

--- a/src/mdhlp/lbl_list_matching_vals.md
+++ b/src/mdhlp/lbl_list_matching_vals.md
@@ -11,6 +11,7 @@ __lbl_list_matching_vals__ [varlist], __pattern__(_string_) [__**neg**ate__ __**
 | __pattern__(_string_)   | Pattern to find in an answer option. Provide either a substring or a regular expression.  |
 | __**neg**ate__   | Inverts the search, returning value labels that do __not__match the pattern.  |
 | __**v**erbose__   | Print out labels that match query. Output corresponds to `label list lblnames`.  |
+| __varlist__(_varlist_) | Restrict the scope of variables to consider |
 
 # Description
 

--- a/src/mdhlp/lbl_list_matching_vals.md
+++ b/src/mdhlp/lbl_list_matching_vals.md
@@ -1,0 +1,29 @@
+# Title
+
+__lbl_list_matching_vals__ - This command is used for short description.
+
+# Syntax
+
+__lbl_list_matching_vals__ , __**opt**ion1__(_string_)
+
+| _options_ | Description |
+|-----------|-------------|
+| __**opt**ion1__(_string_)   | Short description of option1  |
+
+# Description
+<!-- Longer description of the intended use of the command and best practices related to the usage. -->
+
+# Options
+<!-- Longer description (paragraph length) of all options, their intended use case and best practices related to them. -->
+
+__**opt**ion1__(_string_) is used for xyz. Longer description (paragraph length) of all options, their intended use case and best practices related to them.
+
+# Examples
+<!-- A couple of examples to help the user get started and a short explanation of each of them. -->
+
+# Feedback, bug reports and contributions
+<!-- A couple of examples to help the user get started and a short explanation of each of them. -->
+
+# Authors
+
+TODO: Populate this field from .pkg file

--- a/src/sthlp/lbl_list_matching_vals.sthlp
+++ b/src/sthlp/lbl_list_matching_vals.sthlp
@@ -1,0 +1,122 @@
+{smcl}
+{* 01 Jan 1960}{...}
+{hline}
+{pstd}help file for {hi:lbl_list_matching_vals}{p_end}
+{hline}
+
+{title:Title}
+
+{phang}{bf:lbl_list_matching_vals} - List value labels whose labels match a pattern.
+{p_end}
+
+{title:Syntax}
+
+{phang}{bf:lbl_list_matching_vals} [varlist], {bf:pattern}({it:string}) [{bf:{ul:neg}ate} {bf:{ul:v}erbose}]
+{p_end}
+
+{synoptset 16}{...}
+{synopthdr:options}
+{synoptline}
+{synopt: {bf:pattern}({it:string})}Pattern to find in an answer option. Provide either a substring or a regular expression.{p_end}
+{synopt: {bf:{ul:neg}ate}}Inverts the search, returning value labels that do {bf:not}match the pattern.{p_end}
+{synopt: {bf:{ul:v}erbose}}Print out labels that match query. Output corresponds to {inp:label list lblnames}.{p_end}
+{synopt: {bf:varlist}({it:varlist})}Restrict the scope of variables to consider{p_end}
+{synoptline}
+
+{title:Description}
+
+{pstd}While Stata offers some tools for searching the content of variable labels (e.g. {inp:lookfor}), it does not have any methods for similarly searching the contents of value labels.
+{p_end}
+
+{pstd}This command aims fill this gap by:
+{p_end}
+
+{pstd}- Searching labels in value labels for a pattern
+- Identifying variable labels that contain labels of interest
+- Compiling variables that have these labels of interest attached
+{p_end}
+
+{pstd}This command can be particularly useful for checking that variable do (not) contain patterns of interest. Consider for example:
+{p_end}
+
+{pstd}- Confirming that value labels contain (e.g., no)
+- Identifying value labels that deviate from standards
+{p_end}
+
+{title:Options}
+
+{pstd}{bf:pattern}({it:string}) provides the text pattern to find in the contents of value labels. Rather be the traitional Stata glob pattern, this pattern is a sub-string or a regular expression.
+{p_end}
+
+{pstd}{bf:negate} inverts the search, returning value labels that do {bf:not}match the pattern. In isolation, {inp:pattern({c 34}my_text{c 34})} looks for value labels containing {inp:{c 34}my_text{c 34}}. With {inp:negate}, {inp:pattern({c 34}my_search{c 34})} search looks instead for value labels that do not contain {inp:{c 34}my_text{c 34}}.
+{p_end}
+
+{pstd}{bf:verbose} manages the how much output is printed. If the {inp:verbose} option is not provided, {inp:lbl_list_matching_vals} reports on whether any matches were found--and, if so, how many value labels match and how many variables the matching value labels describe. If the {inp:verbose} option is specified, the command will additionally print the contents of the matching value labels as a convenience.
+{p_end}
+
+{title:Examples}
+
+{dlgtab:Example 1: contain a pattern}
+
+{input}{space 8}* create some fake data
+{space 8}gen var1 = .
+{space 8}gen var2 = .
+{space 8}gen var3 = .
+{space 8}gen var4 = .
+{space 8}
+{space 8}* create some value labels
+{space 8}label define var1_lbl 1 "Yes" 2 "No"
+{space 8}label define var2_lbl 1 "Oui" 2 "Non" 3 "Oui, oui"
+{space 8}label define var4_lbl 1 "Oui" 2 "Non"
+{space 8}
+{space 8}* apply those labels to some, but not all, variables
+{space 8}label values var1 var1_lbl
+{space 8}label values var2 var2_lbl
+{space 8}label values var4 var4_lbl
+{space 8}
+{space 8}* find value labels with "Oui" and/or "oui" in at least one constituent label
+{space 8}lbl_list_matching_vals, pattern("[Oo]ui")
+{space 8}
+{space 8}* find value labels and print out the contents of the label, for convenience
+{space 8}* i.e., to avoid the next step that many users might logically make: 
+{space 8}* `label list matching_lbl` 
+{space 8}lbl_list_matching_vals, pattern("[Oo]ui") verbose
+{text}
+{dlgtab:Example 2: do not contain a pattern}
+
+{input}{space 8}* find value labels that do not contain a certain pattern
+{space 8}* for example, no "Oui"/"oui" in yes/no labels from a French-language survey 
+{space 8}lbl_list_matching_vals, pattern("[Oo]ui") negate
+{text}
+{dlgtab:Example 3: contain only a certain set of characters}
+
+{input}{space 8}* create some value labels
+{space 8}label drop _all
+{space 8}* var1_lbl var2_lbl var4_lbl
+{space 8}label define var1_lbl 1 "YES" 2 "NO"
+{space 8}label define var2_lbl 1 "Yes" 2 "No"
+{space 8}label define var3_lbl 1 "yes" 2 "no"
+{space 8}label define var4_lbl 1 "Où" 2 "Là"
+{space 8}
+{space 8}* attach them to variables created above
+{space 8}label values var1 var1_lbl
+{space 8}label values var2 var2_lbl
+{space 8}label values var3 var3_lbl
+{space 8}label values var4 var4_lbl
+{space 8}
+{space 8}* contains no lower-case characters
+{space 8}lbl_list_matching_vals, pattern("[:lower:]") negate
+{space 8}
+{space 8}* contains no French characters
+{space 8}lbl_list_matching_vals, pattern("[àâäÀÂÄéèêëÉÈÊËîïôöÔÖùûüçÇ]") negate
+{space 8}
+{text}
+{title:Feedback, bug reports and contributions}
+
+{pstd}Read more about these commands on {browse "https://github.com/lsms-worldbank/labeller":this repo} where this package is developed. Please provide any feedback by {browse "https://github.com/lsms-worldbank/labeller/issues":opening an issue}. PRs with suggestions for improvements are also greatly appreciated.
+{p_end}
+
+{title:Authors}
+
+{pstd}LSMS Team, The World Bank lsms@worldbank.org
+{p_end}

--- a/src/tests/test-lbl_list_matching_vals.do
+++ b/src/tests/test-lbl_list_matching_vals.do
@@ -1,0 +1,160 @@
+* Kristoffer's root path
+if "`c(username)'" == "wb462869" {
+    global clone "C:\Users\wb462869\github\labeller"
+}
+else if "`c(username)'" == "wb393438" {
+    global clone "C:\Users\wb393438\stata_funs\labeller\labeller"
+}
+
+* Set global to ado_fldr
+global src_fldr  "${clone}/src"
+global test_fldr "${src_fldr}/tests"
+global data_fldr "${test_fldr}/testdata"
+
+* Install the version of this package in
+* the plus-ado folder in the test folder
+cap mkdir "${test_fldr}/plus-ado"
+repado , adopath("${test_fldr}/plus-ado") mode(strict)
+
+cap net uninstall labeller
+net install labeller, from("${src_fldr}") replace
+
+* output version of this package
+labeller
+
+* ==============================================================================
+* Setup
+* ==============================================================================
+
+* create set of variables
+gen var1 = .
+gen var2 = .
+gen var3 = .
+gen var4 = .
+
+* create some value labels
+label define var1_lbl 1 "Yes" 2 "No"
+label define var2_lbl 1 "Oui" 2 "Non" 3 "Oui, oui"
+label define var4_lbl 1 "Oui" 2 "Non"
+
+* apply labels
+label values var1 var1_lbl
+label values var2 var2_lbl
+label values var4 var4_lbl
+
+* ==============================================================================
+* Test
+* ==============================================================================
+
+* ------------------------------------------------------------------------------
+* Lists matching value labels and variables
+* ------------------------------------------------------------------------------
+
+* expect vars: var2 var4 
+* expect val lbls: var2_lbl var4_lbl
+lbl_list_matching_vals, pattern("[Oo]ui")
+local vars_matched = r(varlist)
+local vars_matched : list clean vars_matched
+local val_lbls_matched = r(val_lbl_list)
+local val_lbls_matched : list clean val_lbls_matched
+
+* test variables
+capture assert "`vars_matched'" == "var2 var4"
+di as result "Lists matching variables"
+if _rc != 0 {
+    di as error "❌ Test failed"
+    error 0
+}
+else {
+    di as result "✅ Test passed"
+}
+
+* test value labels
+capture assert "`val_lbls_matched'" == "var2_lbl var4_lbl"
+di as result "Lists matching value labels"
+if _rc != 0 {
+    di as error "❌ Test failed"
+    error 0
+}
+else {
+    di as result "✅ Test passed"
+}
+
+* ------------------------------------------------------------------------------
+* Lists no matches when no matches found
+* ------------------------------------------------------------------------------
+
+* expect: no vars
+* informs no matches
+lbl_list_matching_vals, pattern("Evet")
+local var_count = r(var_count)
+local lbl_count = r(lbl_count)
+
+capture assert "`var_count'" == "0"
+di as result "Lists no variables"
+if _rc != 0 {
+    di as error "❌ Test failed"
+    error 0
+}
+else {
+    di as result "✅ Test passed"
+}
+
+capture assert "`lbl_count'" == "0"
+di as result "Lists no value labels"
+if _rc != 0 {
+    di as error "❌ Test failed"
+    error 0
+}
+else {
+    di as result "✅ Test passed"
+}
+
+* ------------------------------------------------------------------------------
+* Provides verbose output
+* ------------------------------------------------------------------------------
+
+* expect output equivalent to: label list var2_lbl var4_lbl
+lbl_list_matching_vals, pattern("[Oo]ui") verbose
+
+
+* ------------------------------------------------------------------------------
+* Inverts list when negate specified
+* ------------------------------------------------------------------------------
+
+* expect variables: var1
+* expect values: var1_lbl
+lbl_list_matching_vals, pattern("[Oo]ui") negate
+local vars_matched = r(varlist)
+local vars_matched : list clean vars_matched
+local val_lbls_matched = r(val_lbl_list)
+local val_lbls_matched : list clean val_lbls_matched
+
+* test variables
+capture assert "`vars_matched'" == "var1"
+di as result "Lists matching variables"
+if _rc != 0 {
+    di as error "❌ Test failed"
+    error 0
+}
+else {
+    di as result "✅ Test passed"
+}
+
+* test value labels
+capture assert "`val_lbls_matched'" == "var1_lbl"
+di as result "Lists matching value labels"
+if _rc != 0 {
+    di as error "❌ Test failed"
+    error 0
+}
+else {
+    di as result "✅ Test passed"
+}
+
+
+
+* ==============================================================================
+* Teardown
+* ==============================================================================
+

--- a/src/tests/test-lbl_list_matching_vals.do
+++ b/src/tests/test-lbl_list_matching_vals.do
@@ -26,6 +26,8 @@ labeller
 * Setup
 * ==============================================================================
 
+clear
+
 * create set of variables
 gen var1 = .
 gen var2 = .
@@ -230,3 +232,5 @@ else {
 * Teardown
 * ==============================================================================
 
+drop var1 - var5
+label drop var1_lbl var2_lbl var4_lbl

--- a/src/tests/test-lbl_list_matching_vals.do
+++ b/src/tests/test-lbl_list_matching_vals.do
@@ -81,6 +81,40 @@ else {
 }
 
 * ------------------------------------------------------------------------------
+* Lists matching value labels and variables in varlist
+* ------------------------------------------------------------------------------
+
+* expect vars: var2
+* expect val lbls: var2_lbl
+lbl_list_matching_vals, pattern("[Oo]ui") varlist(var1 - var2)
+local vars_matched_in_varlist = r(varlist)
+local vars_matched_in_varlist : list clean vars_matched_in_varlist
+local val_lbls_matched = r(val_lbl_list)
+local val_lbls_matched : list clean val_lbls_matched
+
+* test variables
+capture assert "`vars_matched_in_varlist'" == "var2"
+di as result "Lists matching variables"
+if _rc != 0 {
+    di as error "❌ Test failed"
+    error 0
+}
+else {
+    di as result "✅ Test passed"
+}
+
+* test value labels
+capture assert "`val_lbls_matched'" == "var2_lbl"
+di as result "Lists matching value labels"
+if _rc != 0 {
+    di as error "❌ Test failed"
+    error 0
+}
+else {
+    di as result "✅ Test passed"
+}
+
+* ------------------------------------------------------------------------------
 * Lists no matches when no matches found
 * ------------------------------------------------------------------------------
 
@@ -132,6 +166,44 @@ local val_lbls_matched : list clean val_lbls_matched
 
 * test variables
 capture assert "`vars_matched'" == "var1"
+di as result "Lists matching variables"
+if _rc != 0 {
+    di as error "❌ Test failed"
+    error 0
+}
+else {
+    di as result "✅ Test passed"
+}
+
+* test value labels
+capture assert "`val_lbls_matched'" == "var1_lbl"
+di as result "Lists matching value labels"
+if _rc != 0 {
+    di as error "❌ Test failed"
+    error 0
+}
+else {
+    di as result "✅ Test passed"
+}
+
+* ------------------------------------------------------------------------------
+* Inverts list of matches in varlist when negate specified
+* ------------------------------------------------------------------------------
+
+* add a variable with labels
+gen var5 = .
+label values var5 var1_lbl
+
+* expect variables: var1
+* expect values: var1_lbl
+lbl_list_matching_vals, pattern("[Oo]ui") negate varlist(var2 - var5)
+local vars_matched = r(varlist)
+local vars_matched : list clean vars_matched
+local val_lbls_matched = r(val_lbl_list)
+local val_lbls_matched : list clean val_lbls_matched
+
+* test variables
+capture assert "`vars_matched'" == "var5"
 di as result "Lists matching variables"
 if _rc != 0 {
     di as error "❌ Test failed"


### PR DESCRIPTION
Closes #10 

@kbjarkefur , beyond checking this generally, could you help me troubleshoot an issue? For some reason, I cannot create an `sthlp` file for this command. When I use `ad_sthlp, adf()` to do so, I get the following error message:

```
. ad_sthlp, adf("${clone}")
too few quotes
r(132);
```

I suspect that either my md file is malformed or that adodown isn't handling md files properly that incline quotes (e.g., strings in the examples).