### PR TITLE
Add commands to list and drop unused value labels, respectively.

### DIFF
--- a/src/ado/lbl_drop_unused_lbls.ado
+++ b/src/ado/lbl_drop_unused_lbls.ado
@@ -10,37 +10,78 @@ qui {
   syntax , [Confirm]
 
     lbl_list_unused_lbls
-    
+
     * capture and count the list of unused variables
-    local unused_labels "`r(names)'"
-    local n_unused_labels : list sizeof unused_labels
+    local unused_labels   "`r(names)'"
+    local n_unused_labels "`r(count)'"
 
     * report on findings and drop unused labels, if needed
-    if (`n_unused_labels' == 0) {     
-      noi: di as result "{pstd}No unused value labels found.{p_end}"
+    if (`n_unused_labels' == 0) {
+      noi di as text "{pstd}No unused value labels found.{p_end}"
     }
     else if (`n_unused_labels' > 0) {
+
+      noi di as text "{pstd}Unused value labels found:{p_end}"
+
       * if user wants to confirm, issue confirmation prompt
-      if (!mi("`confirm'")) {
-        noi: di as result "{pstd}Unused value labels found:{p_end}"
-        noi: di as result "{phang}`unused_labels'{p_end}"
-        noi: di as result "{phang}Would you like to drop these labels?{p_end}"
-        noi: di as result "{phang}Type y or no to record your choice.{p_end}" _request(to_drop)
+      if mi("`confirm'") {
+        * Add all labels to be removed
+        local lbl_remove "`unused_labels'"
       }
-      * if want to drop or did not request to confirm dropping, drop
-      local want_to_drop = regexm("`to_drop'", "^[Yy]")
-      if ((`want_to_drop' == 1)  | mi("`confirm'")) {
-        noi: di as result "{pstd}Unused value labels dropped:{p_end}"
-        noi: di as result "{phang}`unused_labels'{p_end}"
-        label drop `unused_labels'
+      else {
+
+        *list all unused labels to prompt about so user can answer "ALL"
+        noi di as result "{phang}`unused_labels'{p_end}"
+
+        * Initiate the prompt global to missing
+        global lbl_unused_confirmation ""
+        * Initial locals listing labels to remove or keep
+        local lbl_keep   ""
+        local lbl_remove ""
+
+        * loop over each unused label and prompt for deletion
+        foreach lbl of local unused_labels {
+
+          * If all used for previous label, then apply ALL to all lables
+          if "${lbl_unused_confirmation}" == "ALL" {
+            global lbl_unused_confirmation "ALL"
+          }
+          else global lbl_unused_confirmation ""
+
+          * Prompt until valid answer is given
+          while (!inlist(upper("${lbl_unused_confirmation}"), "Y", "N", "ALL", "BREAK")) {
+            noi di as txt _n `"{pstd}Confirm removal of unused value label: {inp:`lbl'}. Enter "{inp:Y}" to confirm removal, "{inp:N}" to keep this label,  or "{inp:ALL}" to confirm removal of all remaining unused labels listed above not yet prompted about, or enter "{inp:BREAK" to exit this command with no action taken."', _request(lbl_unused_confirmation)
+          }
+
+          if inlist(upper("${lbl_unused_confirmation}"), "Y", "ALL") {
+              local lbl_remove "`lbl_remove' `lbl'"
+          }
+          else if inlist(upper("${lbl_unused_confirmation}"), "N") {
+            local lbl_keep "`lbl_keep' `lbl'"
+          }
+          else if inlist(upper("${lbl_unused_confirmation}"), "BREAK") {
+            noi di as text "{pstd}Command exited with no action taken.{p_end}"
+            error 0
+            exit
+          }
+          else {
+            noi di as text "{pstd}Prompt error. This is a bug and should never happen.{p_end}"
+            error 99
+            exit
+          }
       }
-      else if (`want_to_drop' == 0) {
-        noi: di as result "{pstd}No unused value labels were dropped.{p_end}"
-        noi: di as result "{pstd}However, these unused labels were found:{p_end}"
-        noi: di as result "{phang}`unused_labels'{p_end}"
-      }
+    }
+
+    * Regardless of confirm or not, removing labels here
+    if (`: list sizeof lbl_remove' > 0) {
+      label drop `lbl_remove'
+      noi di as text _n "{phang}These unused labels were dropped: {inp:`lbl_remove'}{p_end}"
+    }
+
+    if (`: list sizeof lbl_keep' > 0) {
+      noi di as text _n "{phang}These unused labels are kept: {inp:`lbl_keep'}{p_end}"
     }
 
   }
-
+}
 end

--- a/src/ado/lbl_drop_unused_lbls.ado
+++ b/src/ado/lbl_drop_unused_lbls.ado
@@ -1,0 +1,46 @@
+*! version XX XXXXXXXXX ADAUTHORNAME ADCONTACTINFO
+
+cap program drop   lbl_drop_unused_lbls
+    program define lbl_drop_unused_lbls
+
+  version /* ADD VERSION NUMBER HERE */
+
+  syntax , [Confirm]
+
+  qui {
+
+    lbl_list_unused_lbls
+    
+    * capture and count the list of unused variables
+    local unused_labels "`r(names)'"
+    local n_unused_labels : list sizeof unused_labels
+
+    * report on findings and drop unused labels, if needed
+    if (`n_unused_labels' == 0) {     
+      noi: di as result "{pstd}No unused value labels found.{p_end}"
+    }
+    else if (`n_unused_labels' > 0) {
+      * if user wants to confirm, issue confirmation prompt
+      if (!mi("`confirm'")) {
+        noi: di as result "{pstd}Unused value labels found:{p_end}"
+        noi: di as result "{phang}`unused_labels'{p_end}"
+        noi: di as result "{phang}Would you like to drop these labels?{p_end}"
+        noi: di as result "{phang}Type y or no to record your choice.{p_end}" _request(to_drop)
+      }
+      * if want to drop or did not request to confirm dropping, drop
+      local want_to_drop = regexm("`to_drop'", "^[Yy]")
+      if ((`want_to_drop' == 1)  | mi("`confirm'")) {
+        noi: di as result "{pstd}Unused value labels dropped:{p_end}"
+        noi: di as result "{phang}`unused_labels'{p_end}"
+        label drop `unused_labels'
+      }
+      else if (`want_to_drop' == 0) {
+        noi: di as result "{pstd}No unused value labels were dropped.{p_end}"
+        noi: di as result "{pstd}However, these unused labels were found:{p_end}"
+        noi: di as result "{phang}`unused_labels'{p_end}"
+      }
+    }
+
+  }
+
+end

--- a/src/ado/lbl_drop_unused_lbls.ado
+++ b/src/ado/lbl_drop_unused_lbls.ado
@@ -50,7 +50,7 @@ qui {
 
           * Prompt until valid answer is given
           while (!inlist(upper("${lbl_unused_confirmation}"), "Y", "N", "ALL", "BREAK")) {
-            noi di as txt _n `"{pstd}Confirm removal of unused value label: {inp:`lbl'}. Enter "{inp:Y}" to confirm removal, "{inp:N}" to keep this label,  or "{inp:ALL}" to confirm removal of all remaining unused labels listed above not yet prompted about, or enter "{inp:BREAK" to exit this command with no action taken."', _request(lbl_unused_confirmation)
+            noi di as txt _n `"{pstd}Confirm removal of unused value label: {inp:`lbl'}. Enter "{inp:Y}" to confirm removal, "{inp:N}" to keep this label,  or "{inp:ALL}" to confirm removal of all remaining unused labels listed above not yet prompted about, or enter "{inp:BREAK}" to exit this command with no action taken."', _request(lbl_unused_confirmation)
           }
 
           if inlist(upper("${lbl_unused_confirmation}"), "Y", "ALL") {

--- a/src/ado/lbl_drop_unused_lbls.ado
+++ b/src/ado/lbl_drop_unused_lbls.ado
@@ -3,11 +3,11 @@
 cap program drop   lbl_drop_unused_lbls
     program define lbl_drop_unused_lbls
 
+qui {
+
   version /* ADD VERSION NUMBER HERE */
 
   syntax , [Confirm]
-
-  qui {
 
     lbl_list_unused_lbls
     

--- a/src/ado/lbl_drop_unused_lbls.ado
+++ b/src/ado/lbl_drop_unused_lbls.ado
@@ -50,7 +50,9 @@ qui {
 
           * Prompt until valid answer is given
           while (!inlist(upper("${lbl_unused_confirmation}"), "Y", "N", "ALL", "BREAK")) {
-            noi di as txt _n `"{pstd}Confirm removal of unused value label: {inp:`lbl'}. Enter "{inp:Y}" to confirm removal, "{inp:N}" to keep this label,  or "{inp:ALL}" to confirm removal of all remaining unused labels listed above not yet prompted about, or enter "{inp:BREAK}" to exit this command with no action taken."', _request(lbl_unused_confirmation)
+            noi di as result _n `"{pstd}Confirm removal of unused value label: {inp:`lbl'}{p_end}."'
+
+            noi di as text `"{pstd}Enter "{inp:Y}" to confirm removal, "{inp:N}" to keep this label,  or "{inp:ALL}" to confirm removal of all remaining unused labels listed above not yet prompted about, or enter "{inp:BREAK}" to exit this command with no action taken.{p_end}"', _request(lbl_unused_confirmation)
           }
 
           if inlist(upper("${lbl_unused_confirmation}"), "Y", "ALL") {
@@ -61,7 +63,7 @@ qui {
           }
           else if inlist(upper("${lbl_unused_confirmation}"), "BREAK") {
             noi di as text "{pstd}Command exited with no action taken.{p_end}"
-            error 0
+            error 1
             exit
           }
           else {

--- a/src/ado/lbl_list_unused_lbls.ado
+++ b/src/ado/lbl_list_unused_lbls.ado
@@ -1,0 +1,49 @@
+*! version XX XXXXXXXXX ADAUTHORNAME ADCONTACTINFO
+
+cap program drop   lbl_list_unused_lbls
+    program define lbl_list_unused_lbls, rclass
+
+  version /* ADD VERSION NUMBER HERE */
+
+  syntax , [Verbose]
+
+  qui {
+
+    * get the names of all labels in memory
+    label dir
+    local val_lbls = r(names)
+    
+    * construct the list of unused value labels
+    * checking to see if each label above is attached to a variable
+    local unused_labels ""
+    foreach val_lbl of local val_lbls {
+      * return the variables with value label attached
+      ds, has(vallabel `val_lbl')
+      * if return is empty--i.e., label not used--add it to list
+      if mi("`r(varlist)'") {
+        local unused_labels "`unused_labels' `val_lbl'"
+      }
+    }
+
+    * compute size of list
+    local n_unused_labels : list sizeof unused_labels
+
+    * report on findings
+    if (`n_unused_labels' == 0) {     
+      noi: di as result "{pstd}No unused value labels found.{p_end}"
+    }
+    else if (`n_unused_labels' > 0) {
+      noi: di as result "{pstd}Unused value labels found:{p_end}"
+      noi: di as result "{phang}`unused_labels'{p_end}"
+      if (!mi("`verbose'")) {
+        noi: label list `unused_labels'
+      }
+    }
+
+    * return results
+    return local names "`unused_labels'"
+    return local count "`n_unused_labels'"
+
+  }
+
+end

--- a/src/ado/lbl_list_unused_lbls.ado
+++ b/src/ado/lbl_list_unused_lbls.ado
@@ -12,7 +12,7 @@ qui {
     * get the names of all labels in memory
     label dir
     local val_lbls "`r(names)'"
-    
+
     * construct the list of unused value labels
     * checking to see if each label above is attached to a variable
     local unused_labels ""
@@ -25,19 +25,32 @@ qui {
       }
     }
 
-    * compute size of list
+    * Count unused labels
     local n_unused_labels : list sizeof unused_labels
 
+    ********************
     * report on findings
-    if (`n_unused_labels' == 0) {     
-      noi: di as result "{pstd}No unused value labels found.{p_end}"
+
+    * No value labels in the data set
+    if (`: list sizeof val_lbls' == 0) {
+      noi: di as text "{pstd}No value labels in data set.{p_end}"
     }
-    else if (`n_unused_labels' > 0) {
-      noi: di as result "{pstd}Unused value labels found:{p_end}"
-      noi: di as result "{phang}`unused_labels'{p_end}"
-      if (!mi("`verbose'")) {
-        noi: label list `unused_labels'
+
+    * No unused value labels in the data set
+    else if (`n_unused_labels' == 0) {
+      noi: di as text "{pstd}No unused value labels found.{p_end}"
+    }
+
+    * Unused value labels found
+    else {
+
+      noi di as text "{pstd}Unused value labels found:{p_end}"
+      * Display only a condensed list
+      if missing("`verbose'") {
+        noi di as result "{phang}`unused_labels'{p_end}"
       }
+      * Display each label and its value
+      else noi: label list `unused_labels'
     }
 
     * return results

--- a/src/ado/lbl_list_unused_lbls.ado
+++ b/src/ado/lbl_list_unused_lbls.ado
@@ -11,7 +11,7 @@ cap program drop   lbl_list_unused_lbls
 
     * get the names of all labels in memory
     label dir
-    local val_lbls = r(names)
+    local val_lbls "`r(names)'"
     
     * construct the list of unused value labels
     * checking to see if each label above is attached to a variable
@@ -41,9 +41,8 @@ cap program drop   lbl_list_unused_lbls
     }
 
     * return results
-    return local names "`unused_labels'"
+    return local names = trim("`unused_labels'")
     return local count "`n_unused_labels'"
-
   }
 
 end

--- a/src/ado/lbl_list_unused_lbls.ado
+++ b/src/ado/lbl_list_unused_lbls.ado
@@ -3,11 +3,11 @@
 cap program drop   lbl_list_unused_lbls
     program define lbl_list_unused_lbls, rclass
 
+qui {
+
   version /* ADD VERSION NUMBER HERE */
 
   syntax , [Verbose]
-
-  qui {
 
     * get the names of all labels in memory
     label dir

--- a/src/labeller.pkg
+++ b/src/labeller.pkg
@@ -20,6 +20,8 @@ d
 d Distribution-Date: 20231109
 d
 *** adofiles
+f ado/lbl_drop_unused_lbls.ado
+f ado/lbl_list_unused_lbls.ado
 f ado/lbl_assert_varlbls.ado
 f ado/lbl_list_no_varlbl.ado
 f ado/lbl_replace_pipe.ado
@@ -32,6 +34,8 @@ f ado/lbl_list_long_varlbl.ado
 f ado/lbl_list_matching_vars.ado
 
 *** helpfiles
+f sthlp/lbl_drop_unused_lbls.sthlp
+f sthlp/lbl_list_unused_lbls.sthlp
 f sthlp/lbl_list_matching_vals.sthlp
 f sthlp/lbl_assert_varlbls.sthlp
 f sthlp/lbl_list_no_varlbl.sthlp

--- a/src/mdhlp/lbl_drop_unused_lbls.md
+++ b/src/mdhlp/lbl_drop_unused_lbls.md
@@ -6,6 +6,10 @@ __lbl_drop_unused_lbls__ - Drop value labels not attached to any variable.
 
 __lbl_drop_unused_lbls__ , [__**c**onfirm__]
 
+| _options_ | Description |
+|-----------|-------------|
+| __**c**onfirm__ | Prompts user before removing any unused value labels  |
+
 # Description
 
 When attached to variables, value labels are an essential part of data documentation. Left unused, they create clutter and, potentially, confusion.

--- a/src/mdhlp/lbl_drop_unused_lbls.md
+++ b/src/mdhlp/lbl_drop_unused_lbls.md
@@ -1,0 +1,51 @@
+# Title
+
+__lbl_drop_unused_lbls__ - Drop value labels not attached to any variable.
+
+# Syntax
+
+__lbl_drop_unused_lbls__ , [__**c**onfirm__]
+
+# Description
+
+When attached to variables, value labels are an essential part of data documentation. Left unused, they create clutter and, potentially, confusion.
+
+To eliminate any unattached value labels, drop them with `lbl_drop_unused_lbls`. To check for and inspect unattached value labels, use `lbl_list_unused_lbls`.
+
+# Options
+
+__**c**onfirm__ lists unused value labels and confirms whether the user indeed wants to drop them. When prompted, the user should type `y` for yes or `n` for no. With this response, the command will perform the appropriate action.
+
+# Examples
+
+```
+* create one variable
+gen v1 = .
+
+* define more than one value label set
+label define v1 1 "yes" 2 "no", modify
+label define v3 1 "oui" 2 "non", modify
+label define v4 1 "evet" 2 "hayır", modify
+
+* attach one value label, but not the others
+label values v1 v1
+
+* drop the value labels not attached (aka unused)
+* if in doubt, ask first
+lbl_drop_unused_lbls, confirm
+n
+* if intrepid, drop without asking
+lbl_drop_unused_lbls
+```
+
+# Feedback, Bug Reports, and Contributions
+
+Read more about the commands in this package at https://github.com/lsms-worldbank/labeller.
+
+Please provide any feedback by opening an issue at https://github.com/lsms-worldbank/labeller/issues.
+
+PRs with suggestions for improvements are also greatly appreciated.
+
+# Authors
+
+LSMS Team, The World Bank lsms@worldbank.org

--- a/src/mdhlp/lbl_list_matching_vals.md
+++ b/src/mdhlp/lbl_list_matching_vals.md
@@ -64,7 +64,7 @@ lbl_list_matching_vals, pattern("[Oo]ui")
 
 * find value labels and print out the contents of the label, for convenience
 * i.e., to avoid the next step that many users might logically make:
-* `label list matching_lbl`
+* [label list matching_lbl]
 lbl_list_matching_vals, pattern("[Oo]ui") verbose
 ```
 

--- a/src/mdhlp/lbl_list_unused_lbls.md
+++ b/src/mdhlp/lbl_list_unused_lbls.md
@@ -1,0 +1,62 @@
+# Title
+
+__lbl_list_unused_lbls__ - Lists value labels not attached to any variable.
+
+# Syntax
+
+__lbl_list_unused_lbls__ , [__**v**erbose__]
+
+| _options_ | Description |
+|-----------|-------------|
+| __**v**erbose__   | Prints the contents of unused value labels with `label list`.  |
+
+# Description
+
+When attached to variables, value labels are an essential part of data documentation. Left unused, they create clutter and, potentially, confusion.
+
+To tidy a data set, data producers should manage value label sets well. 
+But in order to tidy, one needs an inventory of the things that need tidying. To that end, `lbl_list_unused_lbls` lists all value label sets that are unused--in other words, that need to be either attached to a variable or dropped.
+
+# Options
+
+__**v**erbose__ provides the user with more details on unused value labels by printing their contents with `label list`. In this way, the user can decide what should be done with unused labels (e.g. attach them to variables, drop them, etc).
+
+# Examples
+
+## Example 1: List unused value labels
+
+```
+* create one variable
+gen v1 = .
+
+* define more than one value label set
+label define v1 1 "yes" 2 "no", modify
+label define v3 1 "oui" 2 "non", modify
+label define v4 1 "evet" 2 "hayır", modify
+
+* attach one value label, but not the others
+label values v1 v1
+
+* list the value labels not attached (aka unused)
+lbl_list_unused_lbls
+```
+
+## Example 2: List unused value labels and print their contents
+
+```
+* ... continuing from example 1
+* print the contents of the unused labels
+lbl_list_unused_lbls, verbose
+```
+
+# Feedback, Bug Reports, and Contributions
+
+Read more about the commands in this package at https://github.com/lsms-worldbank/labeller.
+
+Please provide any feedback by opening an issue at https://github.com/lsms-worldbank/labeller/issues.
+
+PRs with suggestions for improvements are also greatly appreciated.
+
+# Authors
+
+LSMS Team, The World Bank lsms@worldbank.org

--- a/src/sthlp/lbl_drop_unused_lbls.sthlp
+++ b/src/sthlp/lbl_drop_unused_lbls.sthlp
@@ -1,0 +1,70 @@
+{smcl}
+{* 01 Jan 1960}{...}
+{hline}
+{pstd}help file for {hi:lbl_drop_unused_lbls}{p_end}
+{hline}
+
+{title:Title}
+
+{phang}{bf:lbl_drop_unused_lbls} - Drop value labels not attached to any variable.
+{p_end}
+
+{title:Syntax}
+
+{phang}{bf:lbl_drop_unused_lbls} , [{bf:{ul:c}onfirm}]
+{p_end}
+
+{synoptset 7}{...}
+{synopthdr:options}
+{synoptline}
+{synopt: {bf:{ul:c}onfirm}}Prompts user before removing any unused value labels{p_end}
+{synoptline}
+
+{title:Description}
+
+{pstd}When attached to variables, value labels are an essential part of data documentation. Left unused, they create clutter and, potentially, confusion.
+{p_end}
+
+{pstd}To eliminate any unattached value labels, drop them with {inp:lbl_drop_unused_lbls}. To check for and inspect unattached value labels, use {inp:lbl_list_unused_lbls}.
+{p_end}
+
+{title:Options}
+
+{pstd}{bf:{ul:c}onfirm} lists unused value labels and confirms whether the user indeed wants to drop them. When prompted, the user should type {inp:y} for yes or {inp:n} for no. With this response, the command will perform the appropriate action.
+{p_end}
+
+{title:Examples}
+
+{input}{space 8}* create one variable
+{space 8}gen v1 = .
+{space 8}
+{space 8}* define more than one value label set
+{space 8}label define v1 1 "yes" 2 "no", modify
+{space 8}label define v3 1 "oui" 2 "non", modify
+{space 8}label define v4 1 "evet" 2 "hayır", modify
+{space 8}
+{space 8}* attach one value label, but not the others
+{space 8}label values v1 v1
+{space 8}
+{space 8}* drop the value labels not attached (aka unused)
+{space 8}* if in doubt, ask first
+{space 8}lbl_drop_unused_lbls, confirm
+{space 8}n
+{space 8}* if intrepid, drop without asking
+{space 8}lbl_drop_unused_lbls
+{text}
+{title:Feedback, Bug Reports, and Contributions}
+
+{pstd}Read more about the commands in this package at https://github.com/lsms-worldbank/labeller.
+{p_end}
+
+{pstd}Please provide any feedback by opening an issue at https://github.com/lsms-worldbank/labeller/issues.
+{p_end}
+
+{pstd}PRs with suggestions for improvements are also greatly appreciated.
+{p_end}
+
+{title:Authors}
+
+{pstd}LSMS Team, The World Bank lsms@worldbank.org
+{p_end}

--- a/src/sthlp/lbl_list_matching_vals.sthlp
+++ b/src/sthlp/lbl_list_matching_vals.sthlp
@@ -11,7 +11,7 @@
 
 {title:Syntax}
 
-{phang}{bf:lbl_list_matching_vals} [varlist], {bf:pattern}({it:string}) [{bf:{ul:neg}ate} {bf:{ul:v}erbose}]
+{phang}{bf:lbl_list_matching_vals}, {bf:pattern}({it:string}) [{bf:{ul:neg}ate} {bf:{ul:ver}bose} {bf:{ul:v}arlist}({it:varlist})]
 {p_end}
 
 {synoptset 16}{...}
@@ -19,8 +19,8 @@
 {synoptline}
 {synopt: {bf:pattern}({it:string})}Pattern to find in an answer option. Provide either a substring or a regular expression.{p_end}
 {synopt: {bf:{ul:neg}ate}}Inverts the search, returning value labels that do {bf:not}match the pattern.{p_end}
-{synopt: {bf:{ul:v}erbose}}Print out labels that match query. Output corresponds to {inp:label list lblnames}.{p_end}
-{synopt: {bf:varlist}({it:varlist})}Restrict the scope of variables to consider{p_end}
+{synopt: {bf:{ul:ver}bose}}Print out labels that match query. Output corresponds to {inp:label list lblnames}.{p_end}
+{synopt: {bf:{ul:v}arlist}({it:varlist})}Restrict the scope of variables to consider{p_end}
 {synoptline}
 
 {title:Description}
@@ -48,10 +48,13 @@
 {pstd}{bf:pattern}({it:string}) provides the text pattern to find in the contents of value labels. Rather be the traitional Stata glob pattern, this pattern is a sub-string or a regular expression.
 {p_end}
 
-{pstd}{bf:negate} inverts the search, returning value labels that do {bf:not}match the pattern. In isolation, {inp:pattern({c 34}my_text{c 34})} looks for value labels containing {inp:{c 34}my_text{c 34}}. With {inp:negate}, {inp:pattern({c 34}my_search{c 34})} search looks instead for value labels that do not contain {inp:{c 34}my_text{c 34}}.
+{pstd}{bf:{ul:neg}ate} inverts the search, returning value labels that do {bf:not}match the pattern. In isolation, {inp:pattern({c 34}my_text{c 34})} looks for value labels containing {inp:{c 34}my_text{c 34}}. With {inp:negate}, {inp:pattern({c 34}my_search{c 34})} search looks instead for value labels that do not contain {inp:{c 34}my_text{c 34}}.
 {p_end}
 
-{pstd}{bf:verbose} manages the how much output is printed. If the {inp:verbose} option is not provided, {inp:lbl_list_matching_vals} reports on whether any matches were found--and, if so, how many value labels match and how many variables the matching value labels describe. If the {inp:verbose} option is specified, the command will additionally print the contents of the matching value labels as a convenience.
+{pstd}{bf:{ul:ver}bose} manages the how much output is printed. If the {inp:verbose} option is not provided, {inp:lbl_list_matching_vals} reports on whether any matches were found--and, if so, how many value labels match and how many variables the matching value labels describe. If the {inp:verbose} option is specified, the command will additionally print the contents of the matching value labels as a convenience.
+{p_end}
+
+{pstd}{bf:{ul:v}arlist}({it:varlist}) restricts the scope of the search to the user-provided variable list. By default, the command searches for matches in all variables in memory. With {bf:varlist}(), the scope of the search can be narrowed.
 {p_end}
 
 {title:Examples}
@@ -78,14 +81,14 @@
 {space 8}lbl_list_matching_vals, pattern("[Oo]ui")
 {space 8}
 {space 8}* find value labels and print out the contents of the label, for convenience
-{space 8}* i.e., to avoid the next step that many users might logically make: 
-{space 8}* `label list matching_lbl` 
+{space 8}* i.e., to avoid the next step that many users might logically make:
+{space 8}* [label list matching_lbl]
 {space 8}lbl_list_matching_vals, pattern("[Oo]ui") verbose
 {text}
 {dlgtab:Example 2: do not contain a pattern}
 
 {input}{space 8}* find value labels that do not contain a certain pattern
-{space 8}* for example, no "Oui"/"oui" in yes/no labels from a French-language survey 
+{space 8}* for example, no "Oui"/"oui" in yes/no labels from a French-language survey
 {space 8}lbl_list_matching_vals, pattern("[Oo]ui") negate
 {text}
 {dlgtab:Example 3: contain only a certain set of characters}

--- a/src/sthlp/lbl_list_unused_lbls.sthlp
+++ b/src/sthlp/lbl_list_unused_lbls.sthlp
@@ -1,0 +1,75 @@
+{smcl}
+{* 01 Jan 1960}{...}
+{hline}
+{pstd}help file for {hi:lbl_list_unused_lbls}{p_end}
+{hline}
+
+{title:Title}
+
+{phang}{bf:lbl_list_unused_lbls} - Lists value labels not attached to any variable.
+{p_end}
+
+{title:Syntax}
+
+{phang}{bf:lbl_list_unused_lbls} , [{bf:{ul:v}erbose}]
+{p_end}
+
+{synoptset 7}{...}
+{synopthdr:options}
+{synoptline}
+{synopt: {bf:{ul:v}erbose}}Prints the contents of unused value labels with {inp:label list}.{p_end}
+{synoptline}
+
+{title:Description}
+
+{pstd}When attached to variables, value labels are an essential part of data documentation. Left unused, they create clutter and, potentially, confusion.
+{p_end}
+
+{pstd}To tidy a data set, data producers should manage value label sets well. 
+But in order to tidy, one needs an inventory of the things that need tidying. To that end, {inp:lbl_list_unused_lbls} lists all value label sets that are unused--in other words, that need to be either attached to a variable or dropped.
+{p_end}
+
+{title:Options}
+
+{pstd}{bf:{ul:v}erbose} provides the user with more details on unused value labels by printing their contents with {inp:label list}. In this way, the user can decide what should be done with unused labels (e.g. attach them to variables, drop them, etc).
+{p_end}
+
+{title:Examples}
+
+{dlgtab:Example 1: List unused value labels}
+
+{input}{space 8}* create one variable
+{space 8}gen v1 = .
+{space 8}
+{space 8}* define more than one value label set
+{space 8}label define v1 1 "yes" 2 "no", modify
+{space 8}label define v3 1 "oui" 2 "non", modify
+{space 8}label define v4 1 "evet" 2 "hayır", modify
+{space 8}
+{space 8}* attach one value label, but not the others
+{space 8}label values v1 v1
+{space 8}
+{space 8}* list the value labels not attached (aka unused)
+{space 8}lbl_list_unused_lbls
+{text}
+{dlgtab:Example 2: List unused value labels and print their contents}
+
+{input}{space 8}* ... continuing from example 1
+{space 8}* print the contents of the unused labels
+{space 8}lbl_list_unused_lbls, verbose
+{text}
+{title:Feedback, Bug Reports, and Contributions}
+
+{pstd}Read more about the commands in this package at https://github.com/lsms-worldbank/labeller.
+{p_end}
+
+{pstd}Please provide any feedback by opening an issue at https://github.com/lsms-worldbank/labeller/issues.
+{p_end}
+
+{pstd}PRs with suggestions for improvements are also greatly appreciated.
+{p_end}
+
+{title:Authors}
+
+{pstd}LSMS Team, The World Bank lsms@worldbank.org
+{p_end}

--- a/src/tests/test-lbl_unused_lbls.do
+++ b/src/tests/test-lbl_unused_lbls.do
@@ -68,7 +68,7 @@ label list
 use `lbl_data', clear
 
 * expected result
-local unused_expected "v4 v3"
+local unused_expected "v3 v4"
 
 * capture result
 lbl_list_unused_lbls

--- a/src/tests/test-lbl_unused_lbls.do
+++ b/src/tests/test-lbl_unused_lbls.do
@@ -1,0 +1,86 @@
+* Kristoffer's root path
+if "`c(username)'" == "wb462869" {
+    global clone "C:\Users\wb462869\github\labeller"
+}
+else if "`c(username)'" == "wb393438" {
+    global clone "C:\Users\wb393438\stata_funs\labeller\labeller"
+}
+
+* Set global to ado_fldr
+global src_fldr  "${clone}/src"
+global test_fldr "${src_fldr}/tests"
+global data_fldr "${test_fldr}/testdata"
+
+* Set up a dev environement for testing locally
+cap mkdir    "${tests}/dev-env"
+repado using "${tests}/dev-env"
+
+cap net uninstall labeller
+net install labeller, from("${src_fldr}") replace
+
+* output version of this package
+labeller
+
+* ==============================================================================
+* Setup
+* ==============================================================================
+
+* create one variable
+gen v1 = .
+
+* define more than one value label set
+label define v1 1 "yes" 2 "no", modify
+label define v3 1 "oui" 2 "non", modify
+label define v4 1 "evet" 2 "hayır", modify
+
+* attach one value label, but not the others
+label values v1 v1
+
+* drop the value labels not attached (aka unused)
+lbl_drop_unused_lbls
+
+* ==============================================================================
+* List
+* ==============================================================================
+
+* expected result
+local unused_expected "v4 v3"
+
+* capture result
+lbl_list_unused_lbls
+local unused_returned = r(names)
+local unused_returned : list clean unused_returned
+
+capture assert "`unused_returned'" == "`unused_expected'"
+di as result "lbl_list_unused_lbls finds unused variable labels"
+if _rc != 0 {
+    di as error "❌ Test failed"
+    error 0
+}
+else {
+    di as result "✅ Test passed"
+}
+
+* ==============================================================================
+* Drop
+* ==============================================================================
+
+* expected list of remaining labels
+local lbls_expected "v1"
+
+* drop unused labels
+lbl_drop_unused_lbls
+
+* get remaining labels
+qui: label dir
+local lbls_found = r(names)
+
+capture assert "`lbls_found'" == "`lbls_expected'"
+di as result "lbl_drop_unused_lbls removes all unattached value labels"
+if _rc != 0 {
+    di as error "❌ Test failed"
+    error 0
+}
+else {
+    di as result "✅ Test passed"
+}

--- a/src/tests/test-lbl_unused_lbls.do
+++ b/src/tests/test-lbl_unused_lbls.do
@@ -12,8 +12,8 @@ global test_fldr "${src_fldr}/tests"
 global data_fldr "${test_fldr}/testdata"
 
 * Set up a dev environement for testing locally
-cap mkdir    "${tests}/dev-env"
-repado using "${tests}/dev-env"
+cap mkdir    "${test_fldr}/dev-env"
+repado using "${test_fldr}/dev-env"
 
 cap net uninstall labeller
 net install labeller, from("${src_fldr}") replace
@@ -24,6 +24,8 @@ labeller
 * ==============================================================================
 * Setup
 * ==============================================================================
+
+clear
 
 * create one variable
 gen v1 = .
@@ -36,12 +38,34 @@ label define v4 1 "evet" 2 "hayır", modify
 * attach one value label, but not the others
 label values v1 v1
 
+label list
+
+tempfile lbl_data
+save    `lbl_data', orphans
+
+
+* ==============================================================================
+* Base case
+* ==============================================================================
+
+use `lbl_data', clear
+
+* Show unused labels with and without verbose
+lbl_list_unused_lbls
+return list
+
+lbl_list_unused_lbls, verbose
+
 * drop the value labels not attached (aka unused)
 lbl_drop_unused_lbls
+label list
+
 
 * ==============================================================================
 * List
 * ==============================================================================
+
+use `lbl_data', clear
 
 * expected result
 local unused_expected "v4 v3"
@@ -64,6 +88,8 @@ else {
 * ==============================================================================
 * Drop
 * ==============================================================================
+
+use `lbl_data', clear
 
 * expected list of remaining labels
 local lbls_expected "v1"


### PR DESCRIPTION
This PR defines two new commands:

- `lbl_list_unused_lbls`
- `lbl_drop_unused_lbls`

@kbjarkefur , these commands are something I need for another project. Otherwise, I would be focusing on polishing what we already have.

In addition to a general review, could you please help me with a few things?

- When trying to to create `sthlp` files, I get the same error as before (see [here](https://github.com/lsms-worldbank/labeller/pull/21#issue-2084507748)). Unfortunately, I couldn't find my mistake. There doesn't appear to be--or at least I couldn't find--any line-ending backtick characters.
- Do you see any better ways to prompt the user--or ones more consistent with prompts elsewhere in the package? I seem to recall there's a prompt when looking for/replacing pipes.