### PR TITLE
Command table before installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,24 @@ The goal of labeller is find, fix, and double-check common issues that arise whe
 
 Note also: while this package does not require [selector](https://github.com/lsms-worldbank/selector), some commands in labeller do leverage the questionnaire metadata that selector adds to survey metadata.
 
+## Commands
+
+| Command | Description |
+| --- | --- |
+| [labeller](https://lsms-worldbank.github.io/labeller/reference/labeller.html) | Package command with utilities for the rest of the package
+| [lbl_assert_no_long_varlbl](https://lsms-worldbank.github.io/labeller/reference/lbl_assert_no_long_varlbl.html) | Assert that there is no variable in memory whose variable length exceeds the desired character length. |
+| [lbl_assert_no_pipes](https://lsms-worldbank.github.io/labeller/reference/lbl_assert_no_pipes.html) | Asserts that no variable labels have any pipes |
+| [lbl_assert_have_varlbl](https://lsms-worldbank.github.io/labeller/reference/lbl_assert_have_varlbl.html) | List variables without a variable label. |
+| [lbl_list_long_varlbl](https://lsms-worldbank.github.io/labeller/reference/lbl_list_long_varlbl.html) | List variables whose variable label is longer than the desired character length. |
+| [lbl_list_matching_vars](https://lsms-worldbank.github.io/labeller/reference/lbl_list_matching_vars.html) | Identify variables whose label matches a pattern. |
+| [lbl_list_matching_vals](https://lsms-worldbank.github.io/labeller/reference/lbl_list_matching_vals.html) | List value labels whose labels match a pattern. |
+| [lbl_list_no_varlbl](https://lsms-worldbank.github.io/labeller/reference/lbl_list_no_varlbl.html) | List variables without a variable label. |
+| [lbl_list_pipes](https://lsms-worldbank.github.io/labeller/reference/lbl_list_pipes.html) | Lists pipes in variable labels from Survey Solutions. |
+| [lbl_replace_pipe](https://lsms-worldbank.github.io/labeller/reference/lbl_replace_pipe.html) | Replaces pipes in variable labels with user-provided value |
+
 ##  Installation
 
-To install the latest published version of the package: 
+To install the latest published version of the package:
 
 ```stata
 * install the package from the SSC package repository
@@ -59,21 +74,6 @@ local tag "v1.0"
 net install labeller, ///
   from("https://raw.githubusercontent.com/lsms-worldbank/labeller/`tag'/src") replace
 ```
-
-## Commands
-
-| Command | Description |
-| --- | --- |
-| [labeller](https://lsms-worldbank.github.io/labeller/reference/labeller.html) | Package command with utilities for the rest of the package
-| [lbl_assert_no_long_varlbl](https://lsms-worldbank.github.io/labeller/reference/lbl_assert_no_long_varlbl.html) | Assert that there is no variable in memory whose variable length exceeds the desired character length. |
-| [lbl_assert_no_pipes](https://lsms-worldbank.github.io/labeller/reference/lbl_assert_no_pipes.html) | Asserts that no variable labels have any pipes |
-| [lbl_assert_have_varlbl](https://lsms-worldbank.github.io/labeller/reference/lbl_assert_have_varlbl.html) | List variables without a variable label. |
-| [lbl_list_long_varlbl](https://lsms-worldbank.github.io/labeller/reference/lbl_list_long_varlbl.html) | List variables whose variable label is longer than the desired character length. |
-| [lbl_list_matching_vars](https://lsms-worldbank.github.io/labeller/reference/lbl_list_matching_vars.html) | Identify variables whose label matches a pattern. |
-| [lbl_list_matching_vals](https://lsms-worldbank.github.io/labeller/reference/lbl_list_matching_vals.html) | List value labels whose labels match a pattern. |
-| [lbl_list_no_varlbl](https://lsms-worldbank.github.io/labeller/reference/lbl_list_no_varlbl.html) | List variables without a variable label. |
-| [lbl_list_pipes](https://lsms-worldbank.github.io/labeller/reference/lbl_list_pipes.html) | Lists pipes in variable labels from Survey Solutions. |
-| [lbl_replace_pipe](https://lsms-worldbank.github.io/labeller/reference/lbl_replace_pipe.html) | Replaces pipes in variable labels with user-provided value |
 
 ## Usage
 


### PR DESCRIPTION
I merged your suggestions in https://github.com/lsms-worldbank/labeller/pull/35.

What do you think of this order? https://github.com/lsms-worldbank/labeller/tree/cmd-table-first

The table that gives an overview what this package is about before how to install. That might be a more relevant order to most people visiting the page. 

I have not changed any of the content.